### PR TITLE
feat: url pública para renderização de conteúdo

### DIFF
--- a/app/Http/Controllers/Api/ContentController.php
+++ b/app/Http/Controllers/Api/ContentController.php
@@ -4,13 +4,48 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use stdClass;
 
 class ContentController extends Controller
 {
+    protected function renderContent(string $id, string $content, stdClass $params) {
+        $resultBase64 = '';
+        $contentUrl = route('content.view', ['id' => $id]);
+        
+        // TODO: chamar o puppeter aqui para acessar a url $contentUrl, tirar um print e retornar esse print como base64
+
+        return $resultBase64;
+    }
+
     public function download(Request $request)
     {
-       return response()->json([
-            'download_url' => '',
+        $request->validate([
+            'id' => 'required',
+            'content' => 'required',
+            'params' => 'required'
+        ]);
+
+        $id = $request->input('id');
+        $content = $request->input('content');
+        $params = json_decode($request->input('params', '{}'));
+
+        Log::debug('Content download requested for id=' . $id . "\n" . print_r($params, true) . "\n" . $content);
+        
+        Storage::put($id, $content);
+        $resultBase64 = $this->renderContent($id, $content, $params);
+
+        return response()->json([
+            'image_base64' => $resultBase64,
+        ]);
+    }
+
+    public function view(string $id) {
+        $content = Storage::get($id);
+
+        return response($content, 200, [
+            'Content-Type' => 'text/html'
         ]);
     }
 }

--- a/public/assets/lbk/screens/live-cover/index.html
+++ b/public/assets/lbk/screens/live-cover/index.html
@@ -2,9 +2,12 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
 <head>
+    <base id="baseUrl" href="" />
+
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    
     <title>Live cover</title>
     
     <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
@@ -115,14 +118,14 @@
         </div>
     </div>
 
-    <script src="../../js/jquery-3.5.1.min.js"></script>
+    <script src="../js/jquery-3.5.1.min.js"></script>
     <script>
         $(function () {
             document.body.style.display = 'block';
 
             var parentWindow = window.opener || window.parent;
 
-            if (!parentWindow.LBK) {
+            if (!parentWindow || !parentWindow.LBK) {
                 return;
             }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,8 +16,10 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+Route::get('content/view/{id}', [ContentController::class, 'view'])->name('content.view');
+
 Route::group(['as' => 'api.'], function() {
-    Route::get('download', [ContentController::class, 'download'])->name('content.download');
+    Route::get('content/download', [ContentController::class, 'download'])->name('content.download');
 
     Route::group(['prefix' => 'hint/graphic/'], function() {
         Route::get('any', [HintController::class, 'index'])->name('hint.any');

--- a/storage/app/.gitignore
+++ b/storage/app/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!.gitkeep
+!public/


### PR DESCRIPTION
Esse PR habilita a API do maker e o LBK a terem conteúdos produzidos acessíveis em uma URL pública. Essa url pode ser utilizada por um script node, por exemplo, para gerar um render final do conteúdo.

O funcionamento é o seguinte: o LBK envia um id e o conteúdo html completo do iframe de conteúdo para um endpoint (`/api/content/download`). Esse endpoint cria um arquivo no storage do Laravel, que será lido depois pelo endpoint que mostra o conteúdo (`/api/content/view`).

Deixei um `TODO` no método `renderContent()` do controller `ContentController` onde o script node deve ser chamado.