### PR TITLE
Imagens no ibis não são renderizadas a partir do link

### DIFF
--- a/app/Services/GoogleDoc.php
+++ b/app/Services/GoogleDoc.php
@@ -175,8 +175,9 @@ class GoogleDoc
             if (!empty($output_array)){
                 $title = $output_array[1];
                 $link = $output_array[2];
-                $bookId = $this->parseUrl($link);
-                if(!empty($bookId)){
+                $bookIdArray = $this->parseUrl($link);
+                if(!empty($bookIdArray)){
+                    $bookId = $bookIdArray[0];
                     $newLink = "https://drive.google.com/uc?export=view&id=$bookId";
                     $arrayOfLines[$currentLine] = "![$title]($newLink)";
                 } else {
@@ -190,7 +191,7 @@ class GoogleDoc
 
     public function parseUrl($url){
         preg_match('/(?<=\/d\/).*(?=\/view)/', $url, $id);
-        return $id[0];
+        return $id;
     }
 
     public function parseLineArrayToChapterArray($arrayOfLines){

--- a/app/Services/GoogleDoc.php
+++ b/app/Services/GoogleDoc.php
@@ -55,7 +55,7 @@ class GoogleDoc
             $fileInfo['error'] = '';
             return $fileInfo;
         } catch (\Google_Service_Exception $e){
-            $fileInfo['error'] = 'Arquivo não encontrado, verifique se você compartilhou corretamente o seu Google Docs com practiceuffs.maker@gmail.com';
+            $fileInfo['error'] = 'Arquivo não encontrado, verifique se você compartilhou corretamente o seu Google Docs no modo \'Editor\'';
             return $fileInfo;
         }
     }
@@ -86,7 +86,7 @@ class GoogleDoc
             return $fileInfo;
 
         } catch (\Google_Service_Exception $e){
-            $fileInfo['error'] = 'Arquivo não encontrado, verifique se você compartilhou corretamente o seu Google Docs com practiceuffs.maker@gmail.com';
+            $fileInfo['error'] = 'Arquivo não encontrado, verifique se você compartilhou o documento no modo \'Editor\'!';
             return $fileInfo;
         }
     }
@@ -98,6 +98,8 @@ class GoogleDoc
             $content = $response->getBody()->getContents();
 
             $arrayOfLines = $this->parseDocsToArray($content);
+
+            $arrayOfLines = $this->findImageAndAdaptLink($arrayOfLines);
 
             $bookContent = $this->parseLineArrayToChapterArray($arrayOfLines);
 
@@ -162,6 +164,33 @@ class GoogleDoc
         }
 
         return $arrayOfLines;
+    }
+
+    public function findImageAndAdaptLink($arrayOfLines){
+        $currentLine = 0;
+        
+        foreach ($arrayOfLines as $line) {
+            preg_match('/!\[(.*)\]\((.*)\)/', $line, $output_array);
+            $oldLine = $line;
+            if (!empty($output_array)){
+                $title = $output_array[1];
+                $link = $output_array[2];
+                $bookId = $this->parseUrl($link);
+                if(!empty($bookId)){
+                    $newLink = "https://drive.google.com/uc?export=view&id=$bookId";
+                    $arrayOfLines[$currentLine] = "![$title]($newLink)";
+                } else {
+                    $arrayOfLines[$currentLine] = $oldLine;
+                }
+            } 
+            $currentLine = $currentLine + 1;
+        } 
+        return $arrayOfLines;
+    }
+
+    public function parseUrl($url){
+        preg_match('/(?<=\/d\/).*(?=\/view)/', $url, $id);
+        return $id[0];
     }
 
     public function parseLineArrayToChapterArray($arrayOfLines){


### PR DESCRIPTION
Isso que está aqui embaixo resolve o problema sobre salvar as imagens para poder mostralas no livro digital, desta maneira basta salva-las no Drive, permitir o compartilhamento para todas as pessoas com o link e colocar o link em  ```![titulo](link aqui)``` que o maker vai traduzir o link para um link que funciona para ele...

O link que vem do Docs:
![image](https://user-images.githubusercontent.com/48657331/161748247-81c93469-5638-4a03-8a59-d9a2f1d25344.png)

O link depois de alterado: 
![image](https://user-images.githubusercontent.com/48657331/161748320-33d78e98-9936-4d4a-9deb-47599433716d.png)

fix: #63 